### PR TITLE
Update eshoponweb-cicd-testdev.yml

### DIFF
--- a/.github/workflows/eshoponweb-cicd-testdev.yml
+++ b/.github/workflows/eshoponweb-cicd-testdev.yml
@@ -66,14 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: buildandtest
     permissions: {}
-    environment:
-      name: "Development"
-    steps:
-      - name: Download application artifact
-        uses: actions/download-artifact@v6
-        with:
-          name: dotnet-app
-          path: dotnet-app
+
 
       - name: Download ARM template artifact
         uses: actions/download-artifact@v6


### PR DESCRIPTION
This pull request makes a minor update to the CI/CD workflow configuration by removing the explicit specification of the "Development" environment and the step that downloads the application artifact in the deployment job. This change simplifies the deployment process for the test development environment.

- **CI/CD Workflow Simplification:**
  - [`.github/workflows/eshoponweb-cicd-testdev.yml`](diffhunk://#diff-6490bb3392c795b0b4f7b567c263d41c4b5fe04451ec5c5fa9f1324e0eb33870L69-R69): Removed the `environment` key specifying "Development" and the step that downloads the `dotnet-app` artifact in the deployment job.